### PR TITLE
Updated the URL for checking warranty

### DIFF
--- a/warranty.rb
+++ b/warranty.rb
@@ -11,7 +11,7 @@ require 'date'
 
 def get_warranty(serial)
   hash = {}
-  open('https://selfsolve.apple.com/warrantyChecker.do?sn=' + serial.upcase + '&country=USA') {|item|
+  open('https://selfsolve.apple.com/GetWarranty.do?sn=' + serial.upcase + '&country=USA') {|item|
     item.each_line {|item|}
     warranty_array = item.strip.split('"')
     warranty_array.each {|array_item|


### PR DESCRIPTION
The URL wasn't working. Looks like at some point it was changed from 'warrantyChecker' to 'GetWarranty'.
