### PR TITLE
v 1.2 (updated for better large-scale usage)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ warranty
 Apple warranty lookup script.
 
 This script scrapes Apple's warranty self serve site to determine whether a
-given serial number is under warranty. Input can be one or more given 
+given serial number is under warranty. Input can be one or more given
 serial numbers, or a text file listing serials. Output can be standard out
 or a CSV file.
 
@@ -13,18 +13,26 @@ All of the good ideas herein came from [glarizza][1], except for the rest of the
 Usage
 -----------
 
-	usage: warranty [-h] [-i INPUT] [-o OUTPUT] ...
+	usage: warranty [-h] [-v] [--quit-on-error] [-i INPUT] [-o OUTPUT] ...
 
 	positional arguments:
 	  serials
 
 	optional arguments:
 	  -h, --help            show this help message and exit
+	  -v, --verbose         print output to console while writing to file
+	  --quit-on-error       if an error is encountered
 	  -i INPUT, --input INPUT
 	                        import serials from a file
 	  -o OUTPUT, --output OUTPUT
 	                        save output to a csv file
 
+Updates
+-------
+
+	Updated September 22, 2014 by Pierce Darragh.
+	New version now can handle large lists with bad serial numbers.
+	Also outputs information during runtime.
 
 License
 -------

--- a/warranty
+++ b/warranty
@@ -2,19 +2,29 @@
 
 ##############################################################################
 # Copyright 2014 Joseph Chilcote
-# 
+#
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy
-#  of the License at  
-# 
+#  of the License at
+#
 #       http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 #  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #  License for the specific language governing permissions and limitations
 #  under the License.
 ##############################################################################
+# Updates
+#
+# September 23, 2014 [Pierce Darragh]
+#  * variable instantiation in scrape_warranty_site
+#  * fixed output
+#  * fixed error handling (can continue despite errors)
+#  * more pythonic
+#  * added 'verbose' flag (prints output to console and file)
+#  * added 'quit-on-error' flag (if an error is encountered, terminate)
+#  * no more use of `f = open(file)`; replaced by `with open(file) as f`
 
 ## Warranty site
 ## https://selfsolve.apple.com/wcResults.do?sn=SERIAL&Continue=Continue&cn=&locale=&caller=&num=0
@@ -23,21 +33,24 @@
 Apple warranty lookup script.
 
 This script scrapes Apple's warranty self serve site to determine whether a
-given serial number is under warranty. Input can be one or more given 
+given serial number is under warranty. Input can be one or more given
 serial numbers, or a text file listing serials. Output can be standard out
 or a CSV file.
 
-usage: warranty [-h] [-i INPUT] [-o OUTPUT] ...
+usage: warranty [-h] [-v] [--quit-on-error] [-i INPUT] [-o OUTPUT] ...
 
 positional arguments:
   serials
 
 optional arguments:
   -h, --help            show this help message and exit
+  -v, --verbose         print output to console while writing to file
+  --quit-on-error       if an error is encountered
   -i INPUT, --input INPUT
                         import serials from a file
   -o OUTPUT, --output OUTPUT
                         save output to a csv file
+
 '''
 
 import os
@@ -57,7 +70,7 @@ except:
     setattr(requests,'content','')
     def get(self, urlstr, params={}):
         if (params):
-            urlstr += "?%s" % urllib.urlencode(params)
+            urlstr += "?{}".format(urllib.urlencode(params))
         self.content = self.urlopen(urlstr).read()
         return self
     requests.get = types.MethodType(get,requests)
@@ -72,26 +85,30 @@ def get_asd_plist():
 
 def get_serial():
     '''Returns the serial number of this Mac'''
-    print 'Using this machine\'s serial number.'
-    output = subprocess.check_output(['/usr/sbin/ioreg', '-c', 
+    print('Using this machine\'s serial number.')
+    output = subprocess.check_output(['/usr/sbin/ioreg', '-c',
                                     'IOPlatformExpertDevice', '-d', '2'])
     for line in output.splitlines():
         if 'IOPlatformSerialNumber' in line:
             return line.split(' = ')[1].replace('\"','')
     return None
 
-def scrape_warranty_site(serial, debug=False):
+def scrape_warranty_site(serial, graceful=True):
     '''Returns raw html from apple's warranty site'''
     # got this code from: https://github.com/pudquick/pyMacWarranty
     warranty_status = requests.get('https://selfsolve.apple.com/wcResults.do',
-        params={'sn': serial, 'Continue': 'Continue', 'cn': '', 'locale': '', 
+        params={'sn': serial, 'Continue': 'Continue', 'cn': '', 'locale': '',
                                         'caller': '', 'num': '0'}).content
-    if debug:
-        print warranty_status
-        sys.exit(0)
+    
+    # instantiate return values to prevent errors
+    model  = ''
+    date   = ''
+    status = ''
+
     if 'serial number is not valid' in warranty_status:
-        print 'Serial number is not valid: %s' % serial
-        sys.exit(0)
+        print('Serial number is not valid: {}'.format(serial))
+        if not graceful:
+            sys.exit(0)
     eligible = True
     for line in warranty_status.splitlines():
         if 'warrantyPage.warrantycheck.displayProductInfo' in line:
@@ -108,21 +125,23 @@ def scrape_warranty_site(serial, debug=False):
             if 'warrantyPage.warrantycheck.displayHWSupportInfo' in line:
                 status = line.split('Coverage: ')[1].split('\',')[0]
     else:
-        date = 'Expired'
+        date   = 'Expired'
         status = 'Inactive'
-    return model, date, status  
+    return model, date, status
 
 def main():
     '''Main method'''
     serials = []
     warranty = []
     parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--verbose', help='print output to console while writing to file', action='store_true')
+    parser.add_argument('--quit-on-error', help='if an error is encountered', action='store_true')
     parser.add_argument('-i', '--input', help='import serials from a file')
     parser.add_argument('-o', '--output', help='save output to a csv file')
     parser.add_argument('serials', nargs=argparse.REMAINDER)
     args = parser.parse_args()
     if args.input:
-        print 'Importing serials from file: %s' % args.input
+        print('Importing serials from file: {}'.format(args.input))
         f = open(args.input, 'r')
         for line in f.read().splitlines():
             serials.append(line)
@@ -131,31 +150,47 @@ def main():
     else:
         serials.append(get_serial())
     d = get_asd_plist()
+    if args.output:
+        print('Writing out to file: {}'.format(args.output))
+        
+        with open(args.output, 'w') as f:
+            f.write('Serial Number,Product Description,Expires,Status,ASD Version\n')
     for serial in serials:
         if args.input:
-            print 'Processing: %s' % serial
-        # (model, date, status) = scrape_warranty_site(serial, debug=True)
-        (model, date, status) = scrape_warranty_site(serial)
+            print('Processing: {}'.format(serial))
+        (model, date, status) = scrape_warranty_site(serial, not args.quit_on_error)
         if model in d:
             asd = d[model]
         else:
             asd = 'Undetermined'
         warranty.append([serial.upper(), model, str(date).split(' ')[0], status, asd])
-    if args.output:
-        print 'Writing out to file: %s' % args.output
-        f = open(args.output, 'w')
-        f.write('Serial Number,Product Description,Expires,Status,ASD Version\n')
-        f.close()
-        for i in warranty:
-            f = open(args.output, 'a')
-            f.write('%s,"%s",%s,%s,%s\n' % (i[0], i[1], i[2], i[3], i[4]))
-            f.close()
+        if args.output:
+            file_output(args.output, warranty[-1])
+            if args.verbose:
+                warranty_output(warranty[-1])
+        else:
+            warranty_output(warranty[-1])
     else:
         for i in warranty:
-            print 'Serial Number:\t\t%s' % i[0]
-            print 'Product Description:\t%s' % i[1]
-            print 'Expires:\t\t%s' % i[2]
-            print 'ASD Version:\t\t%s\n' % i[4]
+            warranty_output(i)
+
+def file_output(file, warranty_info):
+    with open(file, 'a') as f:
+        f.write('{},"{}",{},{},{}\n'.format(
+            warranty_info[0],
+            warranty_info[1],
+            warranty_info[2],
+            warranty_info[3],
+            warranty_info[4])
+        )
+
+def warranty_output(warranty_info):
+    print('Serial Number:       {}'.format(warranty_info[0]))
+    print('Product Description: {}'.format(warranty_info[1]))
+    print('Expires:             {}'.format(warranty_info[2]))
+    print('Status:              {}'.format(warranty_info[3]))
+    print('ASD Version:         {}\n'.format(warranty_info[4]))
+    print('#' * 80)
 
 if __name__ == '__main__':
-  main()
+    main()


### PR DESCRIPTION
- variable instantiation in scrape_warranty_site
- fixed output
- fixed error handling (can continue despite errors)
- more pythonic
- added 'verbose' flag (prints output to console and file)
- added 'quit-on-error' flag (if an error is encountered, terminate)
- no more use of `f = open(file)`; replaced by `with open(file) as f`
