### PR TITLE
Update warranty estimation script for compatibility with both Python 2 and Python 3

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Output can be standard out or a CSV file.
 All of the good ideas herein came from [glarizza][1], except for the rest of the good ideas which came from [pudquick][2]. Every terrible idea is my own.
 
 Usage
------------
+-----
 
 	usage: warranty [-h] [-v] [--quit-on-error] [-i INPUT] [-o OUTPUT] ...
 
@@ -29,14 +29,14 @@ Usage
 License
 -------
 
-	Copyright 2015 Joseph Chilcote
-	
+	Copyright © 2014-2020 Joseph Chilcote
+
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
 	You may obtain a copy of the License at
-	
+
 		http://www.apache.org/licenses/LICENSE-2.0
-	
+
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,
 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/warranty
+++ b/warranty
@@ -43,6 +43,7 @@ optional arguments:
 
 import argparse
 import datetime
+import os
 import subprocess
 import sys
 import time
@@ -77,8 +78,18 @@ def build_args():
 
 def get_asd_plist():
     """Returns a dict containing model and asd version."""
-    asd_plist = "https://raw.githubusercontent.com/chilcote/warranty/master/com.github.chilcote.warranty.plist"
-    response = urlopen(asd_plist)
+    # First try to read from local file.
+    plist_filename = "com.github.chilcote.warranty.plist"
+    if os.path.isfile(plist_filename):
+        with open(plist_filename, "rb") as openfile:
+            asd_plist = openfile.read()
+            return readPlistFromString(asd_plist)
+    # Next try to read from GitHub.
+    plist_url = (
+        "https://raw.githubusercontent.com/chilcote/"
+        "warranty/master/com.github.chilcote.warranty.plist"
+    )
+    response = urlopen(plist_url)
     if response:
         asd_plist = response.read()
         return readPlistFromString(asd_plist)

--- a/warranty
+++ b/warranty
@@ -49,10 +49,11 @@ import time
 import xml.etree.ElementTree as ET
 
 try:
-    from urllib2 import urlopen  # python 2
+    from urllib2 import urlopen, HTTPError  # python 2
     from plistlib import readPlistFromString
 except ImportError:
     from urllib.request import urlopen  # python 3
+    from urllib.error import HTTPError
     from plistlib import loads as readPlistFromString
 
 
@@ -152,7 +153,7 @@ def get_model(serial):
     try:
         url = "http://support-sp.apple.com/sp/product?cc=%s&lang=en_US" % snippet
         model = ET.fromstring(urlopen(url).read()).find("configCode").text
-    except Exception as err:
+    except HTTPError as err:
         print(str(err))
         return None
     return model

--- a/warranty
+++ b/warranty
@@ -1,7 +1,8 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 ##############################################################################
-# Copyright 2014 Joseph Chilcote
+#  Copyright © 2014-2020 Joseph Chilcote
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy

--- a/warranty
+++ b/warranty
@@ -56,6 +56,24 @@ except ImportError:
     from plistlib import loads as readPlistFromString
 
 
+def build_args():
+    """Parse and return command line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="print output to console while writing to file",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--quit-on-error", help="if an error is encountered", action="store_true"
+    )
+    parser.add_argument("-i", "--input", help="import serials from a file")
+    parser.add_argument("-o", "--output", help="save output to a csv file")
+    parser.add_argument("serials", nargs=argparse.REMAINDER)
+    return parser.parse_args()
+
+
 def get_asd_plist():
     """Returns a dict containing model and asd version."""
     asd_plist = "https://raw.githubusercontent.com/chilcote/warranty/master/com.github.chilcote.warranty.plist"
@@ -184,20 +202,7 @@ def main():
     """Main method."""
     serials = []
     warranty = []
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        help="print output to console while writing to file",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--quit-on-error", help="if an error is encountered", action="store_true"
-    )
-    parser.add_argument("-i", "--input", help="import serials from a file")
-    parser.add_argument("-o", "--output", help="save output to a csv file")
-    parser.add_argument("serials", nargs=argparse.REMAINDER)
-    args = parser.parse_args()
+    args = build_args()
 
     if args.input:
         print("Importing serials from file: {}".format(args.input))

--- a/warranty
+++ b/warranty
@@ -20,8 +20,7 @@
 ## Much of this code is forked from by Mike Lynn's work here:
 ## https://github.com/pudquick/pyMacWarranty/blob/master/getwarranty.py
 
-"""
-Apple warranty estimation script.
+"""Apple warranty estimation script.
 
 This script estimates whether a given serial number is under warranty.
 Input can be one or more given serial numbers, or a text file listing serials.
@@ -40,33 +39,38 @@ optional arguments:
                         import serials from a file
   -o OUTPUT, --output OUTPUT
                         save output to a csv file
-
 """
 
 import argparse
 import datetime
-import plistlib
 import subprocess
 import sys
 import time
-import urllib2
 import xml.etree.ElementTree as ET
 
-from dateutil import parser
+try:
+    from urllib2 import urlopen  # python 2
+    from plistlib import readPlistFromString
+except ImportError:
+    from urllib.request import urlopen  # python 3
+    from plistlib import loads as readPlistFromString
 
 
 def get_asd_plist():
-    """Returns a dict containing model and asd version"""
+    """Returns a dict containing model and asd version."""
     asd_plist = "https://raw.githubusercontent.com/chilcote/warranty/master/com.github.chilcote.warranty.plist"
-    response = urllib2.urlopen(asd_plist)
-    return plistlib.readPlist(response)
+    response = urlopen(asd_plist)
+    if response:
+        asd_plist = response.read()
+        return readPlistFromString(asd_plist)
+    return None
 
 
 def get_serial():
-    """Returns the serial number of this Mac"""
+    """Returns the serial number of this Mac."""
     print("Using this machine's serial number.")
     cmd = ["/usr/sbin/ioreg", "-c", "IOPlatformExpertDevice", "-d", "2"]
-    output = subprocess.check_output(cmd)
+    output = subprocess.check_output(cmd).decode()
     for line in output.splitlines():
         if "IOPlatformSerialNumber" in line:
             return line.split(" = ")[1].replace('"', "")
@@ -74,7 +78,7 @@ def get_serial():
 
 
 def apple_year_offset(dateobj, years=0):
-    # Convert to a maleable format
+    # Convert to a malleable format
     mod_time = dateobj.timetuple()
     # Offset year by number of years
     mod_time = time.struct_time(tuple([mod_time[0] + years]) + mod_time[1:])
@@ -83,7 +87,7 @@ def apple_year_offset(dateobj, years=0):
 
 
 def manufacture_date(serial, graceful=True):
-    """returns the estimated manufacture date of the Mac"""
+    """returns the estimated manufacture date of the Mac."""
     # http://www.macrumors.com/2010/04/16/apple-tweaks-serial-number-format-with-new-macbook-pro/
     if 10 < len(serial) < 13:
         if len(serial) == 11:
@@ -105,7 +109,7 @@ def manufacture_date(serial, graceful=True):
             week = serial[4].lower()
             alpha_week = " 123456789cdfghjklmnpqrtvwxy"
             est_week = alpha_week.index(week) + (est_half * 26) - 1
-            year_time = datetime.date(year=est_year, month=1, day=1)
+            year_time = datetime.date(year=int(est_year), month=1, day=1)
             if est_week:
                 week_dif = datetime.timedelta(weeks=est_week)
                 year_time += week_dif
@@ -114,7 +118,7 @@ def manufacture_date(serial, graceful=True):
 
 def get_days_old(manufactured_date):
     today = datetime.datetime.now()
-    manu = parser.parse(manufactured_date)
+    manu = datetime.datetime.strptime(manufactured_date, "%Y-%m-%d")
     return (today - manu).days
 
 
@@ -129,24 +133,23 @@ def get_model(serial):
         return None
     try:
         url = "http://support-sp.apple.com/sp/product?cc=%s&lang=en_US" % snippet
-        model = ET.fromstring(urllib2.urlopen(url).read()).find("configCode").text
-    except Exception:
-        print(Exception)
+        model = ET.fromstring(urlopen(url).read()).find("configCode").text
+    except Exception as err:
+        print(str(err))
         return None
     return model
 
 
 def get_est_warranty(manufactured_date):
+    manu = datetime.datetime.strptime(manufactured_date, "%Y-%m-%d")
     return (
-        u""
-        + apple_year_offset(parser.parse(manufactured_date), 3).strftime("%Y-%m-%d"),
-        u""
-        + apple_year_offset(parser.parse(manufactured_date), 1).strftime("%Y-%m-%d"),
+        u"" + apple_year_offset(manu, 3).strftime("%Y-%m-%d"),
+        u"" + apple_year_offset(manu, 1).strftime("%Y-%m-%d"),
     )
 
 
 def get_est_status(est_date):
-    if datetime.datetime.now() > parser.parse(est_date):
+    if datetime.datetime.now() > datetime.datetime.strptime(est_date, "%Y-%m-%d"):
         return "EXPIRED"
     else:
         return "COVERED"
@@ -178,7 +181,7 @@ def warranty_output(warranty_info):
 
 
 def main():
-    """Main method"""
+    """Main method."""
     serials = []
     warranty = []
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
This pull request adds full Python 3 support for `warranty` while maintaining existing Python 2 behavior. It also uses the local ASD plist file, if it exists (e.g. if `warranty` is being run from a local clone of this repo).

Here's lightly sanitized output that steps through tests of the basic features in both Python 2 and Python 3:

### Python 2 path and version
```
% /usr/bin/python --version
Python 2.7.16
```
### Python 3 path and version
```
% /usr/local/bin/python3 --version
Python 3.7.6
```
### Python 2: Warranty help/usage
```
% /usr/bin/python ./warranty -h
usage: warranty [-h] [-v] [--quit-on-error] [-i INPUT] [-o OUTPUT] ...

positional arguments:
  serials

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         print output to console while writing to file
  --quit-on-error       if an error is encountered
  -i INPUT, --input INPUT
                        import serials from a file
  -o OUTPUT, --output OUTPUT
                        save output to a csv file
```
### Python 3: Warranty help/usage
```
% /usr/local/bin/python3 ./warranty -h
usage: warranty [-h] [-v] [--quit-on-error] [-i INPUT] [-o OUTPUT] ...

positional arguments:
  serials

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         print output to console while writing to file
  --quit-on-error       if an error is encountered
  -i INPUT, --input INPUT
                        import serials from a file
  -o OUTPUT, --output OUTPUT
                        save output to a csv file
```
### Python 2: Warranty default mode (403 error is a warning only)
```
% /usr/bin/python ./warranty
Using this machine's serial number.
HTTP Error 403: Forbidden
Serial Number:       C02FAKE1MD6R
Product Description: None
Est. Manufactured:   2019-11-19
Est. AppleCare:      COVERED
Est. Warranty:       COVERED
Est. Days Old:       45
ASD Version:         Undetermined

```
### Python 3: Warranty default mode (403 error is a warning only)
```
% /usr/local/bin/python3 ./warranty
Using this machine's serial number.
HTTP Error 403: Forbidden
Serial Number:       C02FAKE1MD6R
Product Description: None
Est. Manufactured:   2019-11-19
Est. AppleCare:      COVERED
Est. Warranty:       COVERED
Est. Days Old:       45
ASD Version:         Undetermined

```
### Python 2: Input serials from stdin
```
% /usr/bin/python ./warranty C02FAKE2DHJF YM9FAKE30TG
Serial Number:       C02FAKE2DHJF
Product Description: iMac (21.5-inch, Mid 2011)
Est. Manufactured:   2011-10-15
Est. AppleCare:      EXPIRED
Est. Warranty:       EXPIRED
Est. Days Old:       3002
ASD Version:         3S145

HTTP Error 403: Forbidden
Serial Number:       YM9FAKE30TG
Product Description: None
Est. Manufactured:   2009-02-19
Est. AppleCare:      EXPIRED
Est. Warranty:       EXPIRED
Est. Days Old:       3970
ASD Version:         Undetermined

```
### Python 3: Input serials from stdin
```
% /usr/local/bin/python3 ./warranty C02FAKE2DHJF YM9FAKE30TG
Serial Number:       C02FAKE2DHJF
Product Description: iMac (21.5-inch, Mid 2011)
Est. Manufactured:   2011-10-15
Est. AppleCare:      EXPIRED
Est. Warranty:       EXPIRED
Est. Days Old:       3002
ASD Version:         3S145

HTTP Error 403: Forbidden
Serial Number:       YM9FAKE30TG
Product Description: None
Est. Manufactured:   2009-02-19
Est. AppleCare:      EXPIRED
Est. Warranty:       EXPIRED
Est. Days Old:       3970
ASD Version:         Undetermined

```
### Python 2: Input serials from file
```
% /usr/bin/python ./warranty -i ~/Desktop/input.csv
Importing serials from file: ~/Desktop/input.csv
Processing: C02FAKE4JG5J
Serial Number:       C02FAKE4JG5J
Product Description: MacBook Pro (15-inch, 2018)
Est. Manufactured:   2018-07-23
Est. AppleCare:      COVERED
Est. Warranty:       EXPIRED
Est. Days Old:       529
ASD Version:         Undetermined

Processing: C02FAKE1MD6R
Serial Number:       C02FAKE1MD6R
Product Description: MacBook Pro (16-inch, 2019)
Est. Manufactured:   2019-11-19
Est. AppleCare:      COVERED
Est. Warranty:       COVERED
Est. Days Old:       45
ASD Version:         Undetermined

```
### Python 3: Input serials from file
```
% /usr/local/bin/python3 ./warranty -i ~/Desktop/input.csv
Importing serials from file: ~/Desktop/input.csv
Processing: C02FAKE4JG5J
Serial Number:       C02FAKE4JG5J
Product Description: MacBook Pro (15-inch, 2018)
Est. Manufactured:   2018-07-23
Est. AppleCare:      COVERED
Est. Warranty:       EXPIRED
Est. Days Old:       529
ASD Version:         Undetermined

Processing: C02FAKE1MD6R
Serial Number:       C02FAKE1MD6R
Product Description: MacBook Pro (16-inch, 2019)
Est. Manufactured:   2019-11-19
Est. AppleCare:      COVERED
Est. Warranty:       COVERED
Est. Days Old:       45
ASD Version:         Undetermined

```
### Python 2: Input serials from file, output results to file
```
% /usr/bin/python ./warranty -i ~/Desktop/input.csv -o ~/Desktop/output.csv
Importing serials from file: ~/Desktop/input.csv
Writing out to file: ~/Desktop/output.csv
Processing: C02FAKE4JG5J
Processing: C02FAKE1MD6R

% cat ~/Desktop/output.csv
Serial Number,Product Description,Manufactured,Applecare,Warranty,Age,ASD Version
C02FAKE4JG5J,"MacBook Pro (15-inch, 2018)",2018-07-23,COVERED,EXPIRED,529,Undetermined
C02FAKE1MD6R,"MacBook Pro (16-inch, 2019)",2019-11-19,COVERED,COVERED,45,Undetermined
```
### Python 3: Input serials from file, output results to file
```
% /usr/local/bin/python3 ./warranty -i ~/Desktop/input.csv -o ~/Desktop/output.csv
Importing serials from file: ~/Desktop/input.csv
Writing out to file: ~/Desktop/output.csv
Processing: C02FAKE4JG5J
Processing: C02FAKE1MD6R

% cat ~/Desktop/output.csv
Serial Number,Product Description,Manufactured,Applecare,Warranty,Age,ASD Version
C02FAKE4JG5J,"MacBook Pro (15-inch, 2018)",2018-07-23,COVERED,EXPIRED,529,Undetermined
C02FAKE1MD6R,"MacBook Pro (16-inch, 2019)",2019-11-19,COVERED,COVERED,45,Undetermined
```
