### PR TITLE
Use curl instead of urllib/urllib2 for HTTP operations

### DIFF
--- a/warranty
+++ b/warranty
@@ -50,11 +50,10 @@ import time
 import xml.etree.ElementTree as ET
 
 try:
-    from urllib2 import urlopen, HTTPError  # python 2
+    # Pytnon 2
     from plistlib import readPlistFromString
 except ImportError:
-    from urllib.request import urlopen  # python 3
-    from urllib.error import HTTPError
+    # Python 3
     from plistlib import loads as readPlistFromString
 
 
@@ -89,7 +88,15 @@ def get_asd_plist():
         "https://raw.githubusercontent.com/chilcote/"
         "warranty/master/com.github.chilcote.warranty.plist"
     )
-    response = urlopen(plist_url)
+    cmd = ["/usr/bin/curl", "--silent", "--location", plist_url]
+    try:
+        # Python 3
+        response = subprocess.run(
+            cmd, check=False, text=True, capture_output=True
+        ).stdout
+    except AttributeError:
+        # Python 2
+        response = subprocess.check_output(cmd).decode()
     if response:
         asd_plist = response.read()
         return readPlistFromString(asd_plist)
@@ -100,7 +107,13 @@ def get_serial():
     """Returns the serial number of this Mac."""
     print("Using this machine's serial number.")
     cmd = ["/usr/sbin/ioreg", "-c", "IOPlatformExpertDevice", "-d", "2"]
-    output = subprocess.check_output(cmd).decode()
+    try:
+        # Python 3
+        output = subprocess.run(cmd, check=False, text=True, capture_output=True).stdout
+    except AttributeError:
+        # Python 2
+        output = subprocess.check_output(cmd).decode()
+
     for line in output.splitlines():
         if "IOPlatformSerialNumber" in line:
             return line.split(" = ")[1].replace('"', "")
@@ -161,12 +174,19 @@ def get_model(serial):
         snippet = serial
     else:
         return None
+    url = "http://support-sp.apple.com/sp/product?cc=%s&lang=en_US" % snippet
+    cmd = ["/usr/bin/curl", "--silent", "--location", url]
     try:
-        url = "http://support-sp.apple.com/sp/product?cc=%s&lang=en_US" % snippet
-        model = ET.fromstring(urlopen(url).read()).find("configCode").text
-    except HTTPError as err:
-        print(str(err))
-        return None
+        # Python 3
+        response = subprocess.run(
+            cmd, check=False, text=True, capture_output=True
+        ).stdout
+    except AttributeError:
+        # Python 2
+        response = subprocess.check_output(cmd).decode()
+
+    model = ET.fromstring(response).find("configCode").text
+
     return model
 
 
@@ -181,8 +201,7 @@ def get_est_warranty(manufactured_date):
 def get_est_status(est_date):
     if datetime.datetime.now() > datetime.datetime.strptime(est_date, "%Y-%m-%d"):
         return "EXPIRED"
-    else:
-        return "COVERED"
+    return "COVERED"
 
 
 def file_output(file, warranty_info):

--- a/warranty
+++ b/warranty
@@ -50,7 +50,7 @@ import time
 import xml.etree.ElementTree as ET
 
 try:
-    # Pytnon 2
+    # Python 2
     from plistlib import readPlistFromString
 except ImportError:
     # Python 3


### PR DESCRIPTION
Currently warranty requires SSL verification to communicate with github.com and support-sp.apple.com, and running warranty in Python 3 may not allow this verification to happen, depending on which modules are installed and the state of the local cert store.

Changing HTTP operations to use `curl` instead bypasses this problem, and is backwards compatible with Python 2.

```
% ./warranty
Using this machine's serial number.
Serial Number:       C02ZABCDMD6R
Product Description: MacBook Pro (16-inch, 2019)
Est. Manufactured:   2019-11-19
Est. AppleCare:      COVERED
Est. Warranty:       COVERED
Est. Days Old:       365
ASD Version:         Undetermined

% python3 ./warranty
Using this machine's serial number.
Serial Number:       C02ZABCDMD6R
Product Description: MacBook Pro (16-inch, 2019)
Est. Manufactured:   2019-11-19
Est. AppleCare:      COVERED
Est. Warranty:       COVERED
Est. Days Old:       365
ASD Version:         Undetermined

% /usr/local/munki/munki-python ./warranty
Using this machine's serial number.
Serial Number:       C02ZABCDMD6R
Product Description: MacBook Pro (16-inch, 2019)
Est. Manufactured:   2019-11-19
Est. AppleCare:      COVERED
Est. Warranty:       COVERED
Est. Days Old:       365
ASD Version:         Undetermined
```