### PR TITLE
Read plist from response directly

### DIFF
--- a/warranty
+++ b/warranty
@@ -98,8 +98,7 @@ def get_asd_plist():
         # Python 2
         response = subprocess.check_output(cmd).decode()
     if response:
-        asd_plist = response.read()
-        return readPlistFromString(asd_plist)
+        return readPlistFromString(response)
     return None
 
 


### PR DESCRIPTION
Missed one instance of `response.read()` in the previous PR. This should fix a traceback resulting when an older Mac's model appears in the ASD plist.